### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,5 @@ pytz==2015.2
 raven==5.3.1
 six==1.9.0
 sqlparse==0.1.15
-uWSGI==2.0.10
+uWSGI==2.0.13.1
 wsgiref==0.1.2


### PR DESCRIPTION
This step was failing: install uwsgi server
with this error:

*** uWSGI compiling server core ***\n [x86_64-linux-gnu-gcc -pthread] core/utils.o\n In file included from /usr/include/fcntl.h:289:0,\n from /usr/include/x86_64-linux-gnu/sys/file.h:24,\n from ./uwsgi.h:263,\n from core/utils.c:1:\n In function ‘open’,\n inlined from ‘uwsgi_tmpfd’ at core/utils.c:3472:5:\n /usr/include/x86_64-linux-gnu/bits/fcntl2.h:50:4: error: call to ‘__open_missing_mode’ declared with attribute error: open with O_CREAT or O_TMPFILE in second argument needs 3 arguments\n __open_missing_mode ();